### PR TITLE
Various tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,25 @@ MAINTAINER The GAP Group <support@gap-system.org>
 
 ENV GAP_BRANCH=master
 
+# download and build GAP
 RUN    mkdir /home/gap/inst/ \
     && cd /home/gap/inst/ \
-    && wget -q https://github.com/gap-system/gap/archive/${GAP_BRANCH}.zip \
-    && unzip -q ${GAP_BRANCH}.zip \
-    && rm ${GAP_BRANCH}.zip \
+    && curl https://github.com/gap-system/gap/archive/${GAP_BRANCH}.tar.gz | tar xz \
     && cd gap-${GAP_BRANCH} \
     && ./autogen.sh \
     && ./configure \
     && make \
-    && cp bin/gap.sh bin/gap \
-    && mkdir pkg \
-    && cd pkg \
-    && wget -q https://www.gap-system.org/pub/gap/gap4pkgs/packages-${GAP_BRANCH}.tar.gz \
-    && tar xzf packages-${GAP_BRANCH}.tar.gz \
-    && rm packages-${GAP_BRANCH}.tar.gz \
-    && ../bin/BuildPackages.sh \
-    && test='JupyterKernel-*' \
-    && mv ${test} JupyterKernel \
+    && cp bin/gap.sh bin/gap
+
+# download and build GAP packages
+RUN    mkdir /home/gap/inst/pkg \
+    && cd /home/gap/inst/pkg \
+    && curl https://www.gap-system.org/pub/gap/gap4pkgs/packages-${GAP_BRANCH}.tar.gz | tar xz \
+    && ../bin/BuildPackages.sh
+
+# build JupyterKernel
+RUN    cd /home/gap/inst/pkg \
+    && mv JupyterKernel-* JupyterKernel \
     && cd JupyterKernel \
     && python3 setup.py install --user
 


### PR DESCRIPTION
- download GAP source as .tar.gz, not .zip, as this is smaller
- download using curl (not wget) and directly pipe the output into tar
  (instead of putting it into a temporary file)
- split the big build script into three logical parts


Also contains PR #3 